### PR TITLE
HasFields() now recursively finds all fields in the error chain

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -24,7 +24,7 @@ func (e *ErrTest) Is(target error) bool {
 
 type ErrHasFields struct {
 	M string
-	F map[string]interface{}
+	F map[string]any
 }
 
 func (e *ErrHasFields) Error() string {
@@ -36,7 +36,7 @@ func (e *ErrHasFields) Is(target error) bool {
 	return ok
 }
 
-func (e *ErrHasFields) Fields() map[string]interface{} {
+func (e *ErrHasFields) HasFields() map[string]any {
 	return e.F
 }
 

--- a/fields_test.go
+++ b/fields_test.go
@@ -190,7 +190,7 @@ func TestWithFieldsErrorValue(t *testing.T) {
 }
 
 func TestHasFields(t *testing.T) {
-	hf := &ErrHasFields{M: "error", F: map[string]interface{}{"file": "errors.go"}}
+	hf := &ErrHasFields{M: "error", F: map[string]any{"file": "errors.go"}}
 	err := errors.WithFields{"key1": "value1"}.Wrap(hf, "")
 	m := errors.ToMap(err)
 	require.NotNil(t, m)

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,16 @@ module github.com/mailgun/errors
 go 1.19
 
 require (
-	github.com/ahmetb/go-linq v3.0.0+incompatible // indirect
+	github.com/ahmetb/go-linq v3.0.0+incompatible
+	github.com/mailgun/holster/v4 v4.11.0
+	github.com/sirupsen/logrus v1.9.0
+	github.com/stretchr/testify v1.8.1
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/ahmetb/go-linq v3.0.0+incompatible/go.mod h1:PFffvbdbtw+QTB0WKRP0cNht
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mailgun/holster/v4 v4.11.0 h1:c9DT3QZCfiUgcmOYvxJI9rRhLbtX6IqfaClrMjLxkLE=
+github.com/mailgun/holster/v4 v4.11.0/go.mod h1:sXpF+rzEqA89uBEiX19FrVUdbCUKDfR4GRdXmIkINQQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
@@ -15,8 +19,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/stack.go
+++ b/stack.go
@@ -32,14 +32,14 @@ func (w *withStack) Is(target error) bool {
 	return ok
 }
 
-func (w *withStack) Fields() map[string]interface{} {
+func (w *withStack) HasFields() map[string]any {
 	if child, ok := w.error.(HasFields); ok {
-		return child.Fields()
+		return child.HasFields()
 	}
 
 	var f HasFields
 	if errors.As(w.error, &f) {
-		return f.Fields()
+		return f.HasFields()
 	}
 
 	return nil

--- a/stack.go
+++ b/stack.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -35,6 +36,12 @@ func (w *withStack) Fields() map[string]interface{} {
 	if child, ok := w.error.(HasFields); ok {
 		return child.Fields()
 	}
+
+	var f HasFields
+	if errors.As(w.error, &f) {
+		return f.Fields()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
* HasFields() now recursively finds all fields in the error chain
* No longer using interface{} in favor of 'any' 
* Changed method from `Fields()` to `HasFields()` to avoid collisions with other structs that might have `Fields()`