### PR TITLE
Added errors.Cause()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,12 @@ go 1.19
 
 require (
 	github.com/ahmetb/go-linq v3.0.0+incompatible
-	github.com/mailgun/holster/v4 v4.11.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/ahmetb/go-linq v3.0.0+incompatible/go.mod h1:PFffvbdbtw+QTB0WKRP0cNht
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mailgun/holster/v4 v4.11.0 h1:c9DT3QZCfiUgcmOYvxJI9rRhLbtX6IqfaClrMjLxkLE=
-github.com/mailgun/holster/v4 v4.11.0/go.mod h1:sXpF+rzEqA89uBEiX19FrVUdbCUKDfR4GRdXmIkINQQ=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/wrap.go
+++ b/wrap.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -28,6 +29,17 @@ func Wrapf(err error, format string, a ...any) error {
 		stack:   callstack.New(1),
 		wrapped: err,
 		msg:     fmt.Sprintf(format, a...),
+	}
+}
+
+// Cause returns the last error in the stack of wrapped errors.
+func Cause(err error) error {
+	for {
+		wrapped := errors.Unwrap(err)
+		if wrapped == nil {
+			return err
+		}
+		err = wrapped
 	}
 }
 

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -124,3 +124,12 @@ func TestWrapErrorValue(t *testing.T) {
 	wrap := errors.Wrap(err, "message")
 	assert.True(t, errors.Is(wrap, io.EOF))
 }
+
+func TestCause(t *testing.T) {
+	err := errors.Errorf("error: %w", errors.Wrap(errors.Wrap(errors.New("the cause"), "wrap 2"), "wrap 1"))
+	cause := errors.Cause(err)
+	require.Error(t, err)
+	require.Error(t, cause)
+	assert.Equal(t, "error: wrap 1: wrap 2: the cause", err.Error())
+	assert.Equal(t, "the cause", cause.Error())
+}


### PR DESCRIPTION
### Purpose
`errors.Cause()` returns the last error in the stack of wrapped errors. This is useful if you don't know the type of error you want, but want to get the type of the error that caused the problem.