### PR TITLE
Remove redundant dependencies

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -230,7 +230,6 @@ func ToMap(err error) map[string]any {
 
 // ToLogrus Returns the context and stacktrace information for the underlying error
 // that could be used as logrus.Fields
-// returns empty value if err has no context or no stacktrace
 //
 //	logrus.Fields(errors.ToLogrus(err)).WithField("tid", 1).Error(err)
 func ToLogrus(err error) map[string]any {

--- a/fields.go
+++ b/fields.go
@@ -234,6 +234,10 @@ func ToMap(err error) map[string]any {
 //
 //	logrus.Fields(errors.ToLogrus(err)).WithField("tid", 1).Error(err)
 func ToLogrus(err error) map[string]any {
+	if err == nil {
+		return nil
+	}
+
 	result := map[string]any{
 		"excValue": err.Error(),
 		"excType":  fmt.Sprintf("%T", Unwrap(err)),

--- a/fields.go
+++ b/fields.go
@@ -203,6 +203,10 @@ func (c *fields) FormatFields() string {
 // ToMap Returns the fields for the underlying error as map[string]any
 // If no fields are available returns nil
 func ToMap(err error) map[string]any {
+	if err == nil {
+		return nil
+	}
+
 	result := map[string]any{
 		"excValue": err.Error(),
 		"excType":  fmt.Sprintf("%T", Unwrap(err)),
@@ -233,31 +237,5 @@ func ToMap(err error) map[string]any {
 //
 //	logrus.Fields(errors.ToLogrus(err)).WithField("tid", 1).Error(err)
 func ToLogrus(err error) map[string]any {
-	if err == nil {
-		return nil
-	}
-
-	result := map[string]any{
-		"excValue": err.Error(),
-		"excType":  fmt.Sprintf("%T", Unwrap(err)),
-	}
-
-	// Find any errors with StackTrace information if available
-	var stack callstack.HasStackTrace
-	if Last(err, &stack) {
-		trace := stack.StackTrace()
-		caller := callstack.GetLastFrame(trace)
-		result["excFuncName"] = caller.Func
-		result["excLineNum"] = caller.LineNo
-		result["excFileName"] = caller.File
-	}
-
-	// Search the error chain for fields
-	var f HasFields
-	if errors.As(err, &f) {
-		for key, value := range f.HasFields() {
-			result[key] = value
-		}
-	}
-	return result
+	return ToMap(err)
 }

--- a/fields.go
+++ b/fields.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/mailgun/errors/callstack"
-	"github.com/sirupsen/logrus"
 )
 
 // HasFields Implement this interface to pass along unstructured context to the logger.
@@ -229,12 +228,13 @@ func ToMap(err error) map[string]any {
 	return result
 }
 
-// ToLogrus Returns the context and stacktrace information for the underlying error as logrus.Fields{}
-// returns empty logrus.Fields{} if err has no context or no stacktrace
+// ToLogrus Returns the context and stacktrace information for the underlying error
+// that could be used as logrus.Fields
+// returns empty value if err has no context or no stacktrace
 //
 //	logrus.Fields(errors.ToLogrus(err)).WithField("tid", 1).Error(err)
-func ToLogrus(err error) logrus.Fields {
-	result := logrus.Fields{
+func ToLogrus(err error) map[string]any {
+	result := map[string]any{
 		"excValue": err.Error(),
 		"excType":  fmt.Sprintf("%T", Unwrap(err)),
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/mailgun/errors
 go 1.21
 
 require (
-	github.com/ahmetb/go-linq v3.0.0+incompatible
 	github.com/sirupsen/logrus v1.9.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/ahmetb/go-linq v3.0.0+incompatible h1:qQkjjOXKrKOTy83X8OpRmnKflXKQIL/mC/gMVVDMhOA=
-github.com/ahmetb/go-linq v3.0.0+incompatible/go.mod h1:PFffvbdbtw+QTB0WKRP0cNht7vnCfnGlEpak/DVg5cY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -8,13 +6,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/stack_test.go
+++ b/stack_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/ahmetb/go-linq"
 	"github.com/mailgun/errors"
 	"github.com/mailgun/errors/callstack"
 	"github.com/stretchr/testify/assert"
@@ -48,8 +47,8 @@ func TestStack(t *testing.T) {
 			funcs = append(funcs, fmt.Sprintf("%n", frame))
 		}
 	}
-	assert.True(t, linq.From(files).Contains("stack_test.go"))
-	assert.True(t, linq.From(funcs).Contains("TestStack"), funcs)
+	assert.Contains(t, files, "stack_test.go")
+	assert.Contains(t, funcs, "TestStack")
 }
 
 func TestStackWrapped(t *testing.T) {

--- a/stack_test.go
+++ b/stack_test.go
@@ -31,7 +31,7 @@ func TestWrapWithFieldsAndStack(t *testing.T) {
 
 	trace := stack.StackTrace()
 	caller := callstack.GetLastFrame(trace)
-	assert.Contains(t, fmt.Sprintf("%+v", stack), "errors/stack_test.go:18")
+	assert.Contains(t, fmt.Sprintf("%+v", stack), "errors/stack_test.go:17")
 	assert.Equal(t, "errors_test.TestWrapWithFieldsAndStack", caller.Func)
 	assert.Equal(t, 17, caller.LineNo)
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -33,7 +33,7 @@ func TestWrapWithFieldsAndStack(t *testing.T) {
 	caller := callstack.GetLastFrame(trace)
 	assert.Contains(t, fmt.Sprintf("%+v", stack), "errors/stack_test.go:18")
 	assert.Equal(t, "errors_test.TestWrapWithFieldsAndStack", caller.Func)
-	assert.Equal(t, 18, caller.LineNo)
+	assert.Equal(t, 17, caller.LineNo)
 }
 
 func TestStack(t *testing.T) {


### PR DESCRIPTION
- `github.com/stretchr/testify/assert` has a method to check if a slice contains the value.
- logrus wouldn't be present in indirect dependencies